### PR TITLE
Disable DEBUG flag when compile on Window OS

### DIFF
--- a/build/CommonCompilerOptions.CMake
+++ b/build/CommonCompilerOptions.CMake
@@ -55,10 +55,10 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 
   set(CompilerFlags
           CMAKE_CXX_FLAGS
-          CMAKE_CXX_FLAGS_DEBUG
+          # CMAKE_CXX_FLAGS_DEBUG
           CMAKE_CXX_FLAGS_RELEASE
           CMAKE_C_FLAGS
-          CMAKE_C_FLAGS_DEBUG
+          # CMAKE_C_FLAGS_DEBUG
           CMAKE_C_FLAGS_RELEASE
           )
   foreach(CompilerFlag ${CompilerFlags})


### PR DESCRIPTION
**This PR just a testing. Please don't merge this before we got agreement.**

Currently Window OS try to compile with DEBUG and RELEASE mode the same time.
We have two option:

**Option 1**: Just allow to compile one mode at same time.
**Option 2**: Modify the sub-module to support this kind of build.